### PR TITLE
feat: Support for MD manual for each model

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -479,15 +479,6 @@ def replace_model_thumbnail(
 def get_model_manual(model_id: str):
     path = MANUAL_DIR / f"{model_id}.md"
     if not path.exists():
-        conn = get_db_conn()
-        cur = conn.cursor()
-        cur.execute(
-            "UPDATE models SET manual=NULL WHERE id=? AND manual IS NOT NULL",
-            (model_id,),
-        )
-        if cur.rowcount > 0:
-            conn.commit()
-        conn.close()
         raise HTTPException(status_code=404, detail="Manual not found")
     return FileResponse(path, media_type="text/markdown")
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -23,6 +23,8 @@ from importers import printables
 
 DB_PATH = os.getenv("DB_PATH", "data.db")
 UPLOAD_DIR = Path(os.getenv("FILE_STORAGE", "./app/uploads"))
+MANUAL_DIR = Path(os.getenv("MANUAL_STORAGE", UPLOAD_DIR / "manuals"))
+MANUAL_DIR.mkdir(parents=True, exist_ok=True)
 WEBUI_URL = os.getenv("WEBUI_URL", "http://localhost:8989")
 
 
@@ -70,10 +72,15 @@ def init_db():
             dateAdded INTEGER,
             tags TEXT,
             description TEXT,
-            thumbnail TEXT
+            thumbnail TEXT,
+            manual TEXT
         )
         """
     )
+    try:
+        cur.execute("ALTER TABLE models ADD COLUMN manual TEXT")
+    except sqlite3.OperationalError:
+        pass
     conn.commit()
 
     # seed folders if empty
@@ -119,6 +126,7 @@ def row_to_model(row: sqlite3.Row) -> Dict[str, Any]:
         "tags": tags,
         "description": row["description"] or "",
         "thumbnail": row["thumbnail"],
+        "manual": row["manual"] if "manual" in row.keys() else None,
     }
 
 
@@ -314,6 +322,12 @@ def delete_model(model_id: str):
                 os.remove(os.path.join(UPLOAD_DIR, fname))
             except Exception:
                 pass
+    manual_path = MANUAL_DIR / f"{model_id}.md"
+    if manual_path.exists():
+        try:
+            manual_path.unlink()
+        except Exception:
+            pass
     cur.execute("DELETE FROM models WHERE id=?", (model_id,))
     conn.commit()
     conn.close()
@@ -347,6 +361,12 @@ def bulk_delete(payload: dict):
                     os.remove(os.path.join(UPLOAD_DIR, fname))
                 except Exception:
                     pass
+        manual_path = MANUAL_DIR / f"{mid}.md"
+        if manual_path.exists():
+            try:
+                manual_path.unlink()
+            except Exception:
+                pass
         cur.execute("DELETE FROM models WHERE id=?", (mid,))
     conn.commit()
     conn.close()
@@ -455,11 +475,74 @@ def replace_model_thumbnail(
     return row_to_model(row)
 
 
+@app.get("/api/models/{model_id}/manual")
+def get_model_manual(model_id: str):
+    path = MANUAL_DIR / f"{model_id}.md"
+    if not path.exists():
+        conn = get_db_conn()
+        cur = conn.cursor()
+        cur.execute(
+            "UPDATE models SET manual=NULL WHERE id=? AND manual IS NOT NULL",
+            (model_id,),
+        )
+        if cur.rowcount > 0:
+            conn.commit()
+        conn.close()
+        raise HTTPException(status_code=404, detail="Manual not found")
+    return FileResponse(path, media_type="text/markdown")
+
+
+@app.put("/api/models/{model_id}/manual")
+def upload_model_manual(model_id: str, file: UploadFile = File(...)):
+    conn = get_db_conn()
+    cur = conn.cursor()
+    m = cur.execute("SELECT * FROM models WHERE id=?", (model_id,)).fetchone()
+    if not m:
+        conn.close()
+        raise HTTPException(status_code=404, detail="Model not found")
+
+    path = MANUAL_DIR / f"{model_id}.md"
+    save_upload_file(file, str(path))
+
+    cur.execute(
+        "UPDATE models SET manual=? WHERE id=?",
+        (file.filename, model_id),
+    )
+    conn.commit()
+    row = cur.execute("SELECT * FROM models WHERE id=?", (model_id,)).fetchone()
+    conn.close()
+    return row_to_model(row)
+
+
+@app.delete("/api/models/{model_id}/manual")
+def delete_model_manual(model_id: str):
+    conn = get_db_conn()
+    cur = conn.cursor()
+    m = cur.execute("SELECT * FROM models WHERE id=?", (model_id,)).fetchone()
+    if not m:
+        conn.close()
+        raise HTTPException(status_code=404, detail="Model not found")
+
+    path = MANUAL_DIR / f"{model_id}.md"
+    if path.exists():
+        try:
+            path.unlink()
+        except Exception:
+            pass
+
+    cur.execute("UPDATE models SET manual=NULL WHERE id=?", (model_id,))
+    conn.commit()
+    row = cur.execute("SELECT * FROM models WHERE id=?", (model_id,)).fetchone()
+    conn.close()
+    return row_to_model(row)
+
+
 @app.get("/api/storage-stats")
 def storage_stats():
     used = 0
-    for fname in os.listdir(UPLOAD_DIR):
-        used += os.path.getsize(os.path.join(UPLOAD_DIR, fname))
+    for root, _dirs, files in os.walk(UPLOAD_DIR):
+        for fname in files:
+            used += os.path.getsize(os.path.join(root, fname))
     total = 5 * 1024 * 1024 * 1024
     return {"used": used, "total": total}
 

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -4,6 +4,7 @@ import ModelList from "./components/ModelList";
 import DetailPanel from "./components/DetailPanel";
 import Settings from "./components/Settings";
 import Navbar from "./components/Navbar";
+import ManualModal from "./components/ManualModal";
 import { STLModel, Folder, StorageStats, STLModelCollection } from "./types";
 import { generateThumbnail } from "./services/thumbnailGenerator";
 import { api } from "./services/api";
@@ -80,6 +81,11 @@ const App = () => {
     type: "single" | "bulk" | "folder";
     id?: string;
   }>({ isOpen: false, type: "single" });
+
+  const [manualState, setManualState] = useState<{
+    id: string | null;
+    mode: "view" | "edit";
+  }>({ id: null, mode: "view" });
 
   // Initial Data Fetch
   useEffect(() => {
@@ -177,6 +183,7 @@ const App = () => {
   }, [isMobileSidebarMounted]);
 
   const selectedModel = models.find((m) => m.id === selectedModelId) || null;
+  const manualModel = models.find((m) => m.id === manualState.id) || null;
 
   const currentFolderName =
     currentFolderId === "all"
@@ -396,6 +403,32 @@ const App = () => {
       await api.updateModel(id, updates);
     } catch (error) {
       console.error("Failed to update model:", error);
+    }
+  };
+
+  const handleUploadManual = async (id: string, file: File) => {
+    try {
+      const updated = await api.uploadManual(id, file);
+      setModels((prev) =>
+        prev.map((m) => (m.id === id ? { ...m, manual: updated.manual } : m)),
+      );
+      return updated;
+    } catch (error) {
+      console.error("Failed to upload manual:", error);
+      alert("Failed to upload manual");
+      throw error;
+    }
+  };
+
+  const handleDeleteManual = async (id: string) => {
+    try {
+      const updated = await api.deleteManual(id);
+      setModels((prev) =>
+        prev.map((m) => (m.id === id ? { ...m, manual: updated.manual } : m)),
+      );
+    } catch (error) {
+      console.error("Failed to delete manual:", error);
+      alert("Failed to delete manual");
     }
   };
 
@@ -668,6 +701,9 @@ const App = () => {
                   onImport={handleOpenImport}
                   onSelectModel={(m) => setSelectedModelId(m.id)}
                   onDelete={handleDeleteModel}
+                  onOpenManual={(m) =>
+                    setManualState({ id: m.id, mode: "view" })
+                  }
                   selectedModelId={selectedModelId}
                   // Selection Props
                   selectedIds={selectedIds}
@@ -713,6 +749,14 @@ const App = () => {
                   onClose={() => setSelectedModelId(null)}
                   onUpdate={handleUpdateModel}
                   onDelete={handleDeleteModel}
+                  onOpenManual={(m) =>
+                    setManualState({ id: m.id, mode: "view" })
+                  }
+                  onEditManual={(m) =>
+                    setManualState({ id: m.id, mode: "edit" })
+                  }
+                  onUploadManual={handleUploadManual}
+                  onDeleteManual={handleDeleteManual}
                 />
               </div>
 
@@ -784,6 +828,13 @@ const App = () => {
               )}
 
               {/* Modals Layer */}
+
+              <ManualModal
+                model={manualModel}
+                initialMode={manualState.mode}
+                onClose={() => setManualState({ id: null, mode: "view" })}
+                onSave={handleUploadManual}
+              />
 
               {/* Upload Modal */}
               {showUploadModal && (

--- a/frontend/components/DetailPanel.tsx
+++ b/frontend/components/DetailPanel.tsx
@@ -15,6 +15,7 @@ import {
   RefreshCw,
   AlertTriangle,
   ScreenShareIcon,
+  BookOpen,
 } from "lucide-react";
 
 import { generateThumbnail } from "../services/thumbnailGenerator";
@@ -28,12 +29,18 @@ import TextField from "@mui/material/TextField";
 import Badge from "@mui/material/Badge";
 import Chip from "@mui/material/Chip";
 import Grid from "@mui/material/Grid";
+import IconButton from "@mui/material/IconButton";
+import Tooltip from "@mui/material/Tooltip";
 
 interface DetailPanelProps {
   model: STLModel | null;
   onClose: () => void;
   onUpdate: (id: string, updates: Partial<STLModel>) => void;
   onDelete: (id: string) => void;
+  onOpenManual: (model: STLModel) => void;
+  onEditManual: (model: STLModel) => void;
+  onUploadManual: (id: string, file: File) => void | Promise<void>;
+  onDeleteManual: (id: string) => void | Promise<void>;
 }
 
 const DetailPanel: React.FC<DetailPanelProps> = ({
@@ -41,6 +48,10 @@ const DetailPanel: React.FC<DetailPanelProps> = ({
   onClose,
   onUpdate,
   onDelete,
+  onOpenManual,
+  onEditManual,
+  onUploadManual,
+  onDeleteManual,
 }) => {
   const [isReplacing, setIsReplacing] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
@@ -54,6 +65,7 @@ const DetailPanel: React.FC<DetailPanelProps> = ({
   }>({ show: false, message: "" });
 
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const manualInputRef = useRef<HTMLInputElement>(null);
 
   // Reset local state when model changes
   React.useEffect(() => {
@@ -153,6 +165,18 @@ const DetailPanel: React.FC<DetailPanelProps> = ({
 
   const handleGenerateThumbnail = (dataurl: string) => {
     setTempThumb(dataurl);
+  };
+
+  const handleManualUpload = async (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const file = e.target.files?.[0];
+    if (!file || !model) return;
+    try {
+      await onUploadManual(model.id, file);
+    } finally {
+      if (manualInputRef.current) manualInputRef.current.value = "";
+    }
   };
 
   const handleSave = () => {
@@ -289,6 +313,94 @@ const DetailPanel: React.FC<DetailPanelProps> = ({
             ) : (
               <Typography variant="body2" sx={{ color: "text.secondary" }}>
                 {model.description || "No Description"}
+              </Typography>
+            )}
+          </div>
+          <Divider />
+
+          <div>
+            <Typography variant="body1" gutterBottom>
+              Manual
+            </Typography>
+
+            {isEditing ? (
+              model.manual ? (
+                <Stack
+                  direction="row"
+                  spacing={1}
+                  sx={{ alignItems: "center", minWidth: 0 }}
+                >
+                  <Typography
+                    variant="body2"
+                    sx={{
+                      color: "text.secondary",
+                      flex: 1,
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    {model.manual}
+                  </Typography>
+                  <Tooltip title="Edit manual">
+                    <IconButton
+                      size="small"
+                      onClick={() => onEditManual(model)}
+                      aria-label="edit manual"
+                    >
+                      <Edit className="w-4 h-4" />
+                    </IconButton>
+                  </Tooltip>
+                  <Tooltip title="Delete manual">
+                    <IconButton
+                      size="small"
+                      color="error"
+                      onClick={() => onDeleteManual(model.id)}
+                      aria-label="delete manual"
+                    >
+                      <Trash2 className="w-4 h-4" />
+                    </IconButton>
+                  </Tooltip>
+                </Stack>
+              ) : (
+                <Stack direction="column" spacing={1}>
+                  <Button
+                    fullWidth
+                    component="label"
+                    variant="contained"
+                    startIcon={<FileUp />}
+                  >
+                    Upload Manual
+                    <input
+                      type="file"
+                      ref={manualInputRef}
+                      className="hidden"
+                      accept=".md,.markdown,text/markdown"
+                      onChange={handleManualUpload}
+                    />
+                  </Button>
+                  <Button
+                    fullWidth
+                    variant="outlined"
+                    startIcon={<Edit />}
+                    onClick={() => onEditManual(model)}
+                  >
+                    Or paste
+                  </Button>
+                </Stack>
+              )
+            ) : model.manual ? (
+              <Button
+                fullWidth
+                onClick={() => onOpenManual(model)}
+                variant="outlined"
+                startIcon={<BookOpen />}
+              >
+                Open Manual
+              </Button>
+            ) : (
+              <Typography variant="body2" sx={{ color: "text.secondary" }}>
+                No manual
               </Typography>
             )}
           </div>

--- a/frontend/components/ManualModal.tsx
+++ b/frontend/components/ManualModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { X, Edit, Save } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -31,18 +31,6 @@ const ManualModal: React.FC<ManualModalProps> = ({
   const [loading, setLoading] = useState<boolean>(false);
   const [saving, setSaving] = useState<boolean>(false);
   const [error, setError] = useState<string>("");
-  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
-
-  const autoResizeTextarea = useCallback(() => {
-    const el = textareaRef.current;
-    if (!el) return;
-    el.style.height = "auto";
-    el.style.height = `${el.scrollHeight}px`;
-  }, []);
-
-  useEffect(() => {
-    if (mode === "edit") autoResizeTextarea();
-  }, [mode, draft, autoResizeTextarea]);
 
   useEffect(() => {
     if (!model) return;
@@ -129,7 +117,7 @@ const ManualModal: React.FC<ManualModalProps> = ({
         height: viewportHeight,
         transform: `translate(${visualViewport.offsetLeft}px, ${visualViewport.offsetTop}px)`,
       }}
-      onClick={onClose}
+      onClick={mode === "edit" ? undefined : onClose}
     >
       <div
         className="bg-vault-800 border border-vault-600 rounded-xl shadow-2xl animate-in zoom-in-95 duration-200 flex flex-col w-full max-w-3xl"
@@ -194,12 +182,11 @@ const ManualModal: React.FC<ManualModalProps> = ({
           )}
           {!loading && mode === "edit" && (
             <textarea
-              ref={textareaRef}
               autoFocus
               value={draft}
               onChange={(e) => setDraft(e.target.value)}
               placeholder="Write your manual in Markdown..."
-              className="min-h-[240px] w-full bg-vault-900 border border-vault-700 rounded-md p-3 text-slate-200 font-mono text-sm resize-none outline-none focus:border-blue-500 overflow-hidden"
+              className="flex-1 min-h-[240px] w-full bg-vault-900 border border-vault-700 rounded-md p-3 text-slate-200 font-mono text-sm resize-none outline-none focus:border-blue-500 overflow-y-auto"
             />
           )}
         </div>

--- a/frontend/components/ManualModal.tsx
+++ b/frontend/components/ManualModal.tsx
@@ -1,0 +1,211 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { X, Edit, Save } from "lucide-react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import Tooltip from "@mui/material/Tooltip";
+
+import { STLModel } from "../types";
+import { api } from "../services/api";
+import { useVisualViewport } from "../hooks/useVisualViewport";
+import "./styles/manual.css";
+
+type ManualMode = "view" | "edit";
+
+interface ManualModalProps {
+  model: STLModel | null;
+  onClose: () => void;
+  initialMode?: ManualMode;
+  onSave: (id: string, file: File) => Promise<unknown>;
+}
+
+const ManualModal: React.FC<ManualModalProps> = ({
+  model,
+  onClose,
+  initialMode = "view",
+  onSave,
+}) => {
+  const visualViewport = useVisualViewport();
+  const [mode, setMode] = useState<ManualMode>(initialMode);
+  const [content, setContent] = useState<string>("");
+  const [draft, setDraft] = useState<string>("");
+  const [loading, setLoading] = useState<boolean>(false);
+  const [saving, setSaving] = useState<boolean>(false);
+  const [error, setError] = useState<string>("");
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  const autoResizeTextarea = useCallback(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${el.scrollHeight}px`;
+  }, []);
+
+  useEffect(() => {
+    if (mode === "edit") autoResizeTextarea();
+  }, [mode, draft, autoResizeTextarea]);
+
+  useEffect(() => {
+    if (!model) return;
+    setMode(initialMode);
+    setError("");
+    setContent("");
+    setDraft("");
+
+    if (!model.manual) {
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    fetch(api.getManualUrl(model))
+      .then(async (res) => {
+        if (!res.ok) throw new Error("Failed to load manual");
+        return res.text();
+      })
+      .then((text) => {
+        if (cancelled) return;
+        setContent(text);
+        setDraft(text);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err.message || "Failed to load manual");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [model?.id]);
+
+  useEffect(() => {
+    if (!model) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [model, onClose]);
+
+  if (!model) return null;
+
+  const viewportHeight =
+    visualViewport.height ||
+    (typeof window !== "undefined" ? window.innerHeight : 0);
+
+  const handleSave = async () => {
+    if (!model || saving) return;
+    setSaving(true);
+    setError("");
+    try {
+      const filename = model.manual || "manual.md";
+      const file = new File([draft], filename, { type: "text/markdown" });
+      await onSave(model.id, file);
+      setContent(draft);
+      setMode("view");
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to save manual",
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleCancel = () => {
+    if (!model.manual) {
+      onClose();
+      return;
+    }
+    setDraft(content);
+    setMode("view");
+  };
+
+  return (
+    <div
+      className="fixed left-0 top-0 z-[70] bg-black/60 backdrop-blur-sm flex justify-center items-center p-4"
+      style={{
+        width: "100%",
+        height: viewportHeight,
+        transform: `translate(${visualViewport.offsetLeft}px, ${visualViewport.offsetTop}px)`,
+      }}
+      onClick={onClose}
+    >
+      <div
+        className="bg-vault-800 border border-vault-600 rounded-xl shadow-2xl animate-in zoom-in-95 duration-200 flex flex-col w-full max-w-3xl"
+        style={{ maxHeight: Math.max(240, viewportHeight - 32) }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex justify-between items-center gap-3 p-5 border-b border-vault-700 sticky top-0 bg-vault-800 rounded-t-xl">
+          <div className="flex items-center gap-2 min-w-0 flex-1">
+            <h3 className="text-lg font-bold text-white truncate">
+              {model.name}
+            </h3>
+            {mode === "view" ? (
+              <Tooltip title="Edit manual">
+                <button
+                  onClick={() => setMode("edit")}
+                  className="text-slate-400 hover:text-white shrink-0 p-1 rounded hover:bg-vault-700"
+                  aria-label="Edit manual"
+                >
+                  <Edit className="w-4 h-4" />
+                </button>
+              </Tooltip>
+            ) : (
+              <div className="flex items-center gap-2 shrink-0">
+                <button
+                  onClick={handleSave}
+                  disabled={saving}
+                  className="flex items-center gap-1.5 px-3 py-1.5 text-sm bg-blue-600 hover:bg-blue-500 disabled:bg-vault-700 disabled:text-slate-500 text-white rounded transition-colors"
+                >
+                  <Save className="w-4 h-4" />
+                  {saving ? "Saving..." : "Save"}
+                </button>
+                <button
+                  onClick={handleCancel}
+                  disabled={saving}
+                  className="px-3 py-1.5 text-sm bg-vault-700 hover:bg-vault-600 disabled:opacity-50 text-slate-200 rounded transition-colors"
+                >
+                  Cancel
+                </button>
+              </div>
+            )}
+          </div>
+          <button
+            onClick={onClose}
+            className="text-slate-400 hover:text-white shrink-0"
+            aria-label="Close manual"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <div className="overflow-y-auto px-6 py-5 flex-1 min-h-0 flex flex-col">
+          {loading && (
+            <p className="text-sm text-slate-400 italic">Loading manual...</p>
+          )}
+          {!loading && error && (
+            <p className="text-sm text-red-400 mb-3">{error}</p>
+          )}
+          {!loading && mode === "view" && !error && (
+            <article className="manual-content">
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+            </article>
+          )}
+          {!loading && mode === "edit" && (
+            <textarea
+              ref={textareaRef}
+              autoFocus
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              placeholder="Write your manual in Markdown..."
+              className="min-h-[240px] w-full bg-vault-900 border border-vault-700 rounded-md p-3 text-slate-200 font-mono text-sm resize-none outline-none focus:border-blue-500 overflow-hidden"
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ManualModal;

--- a/frontend/components/ModelList.tsx
+++ b/frontend/components/ModelList.tsx
@@ -13,6 +13,7 @@ import {
   ScreenShareIcon,
   XCircle,
   ChevronLeft,
+  BookOpen,
 } from "lucide-react";
 import { STLModel, Folder } from "../types";
 import { api } from "../services/api";
@@ -50,6 +51,7 @@ interface ModelListProps {
   onImport: () => void;
   onSelectModel: (model: STLModel) => void;
   onDelete: (id: string) => void;
+  onOpenManual: (model: STLModel) => void;
   selectedModelId: string | null;
 
   // Selection Props
@@ -81,6 +83,7 @@ const ModelList: React.FC<ModelListProps> = ({
   onImport,
   onSelectModel,
   onDelete,
+  onOpenManual,
   selectedModelId,
   selectedIds,
   onToggleSelection,
@@ -633,6 +636,19 @@ const ModelList: React.FC<ModelListProps> = ({
                           <ScreenShareIcon />
                         </IconButton>
                       </Tooltip>
+                      {model.manual && (
+                        <Tooltip title="Manual">
+                          <IconButton
+                            aria-label="open manual"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              onOpenManual(model);
+                            }}
+                          >
+                            <BookOpen />
+                          </IconButton>
+                        </Tooltip>
+                      )}
                       <div className="absolute right-2">
                         <IconButton
                           id={`fade-button-${model.id}`}

--- a/frontend/components/styles/manual.css
+++ b/frontend/components/styles/manual.css
@@ -1,0 +1,82 @@
+.manual-content {
+  color: #e2e8f0;
+  line-height: 1.65;
+  word-wrap: break-word;
+}
+.manual-content h1,
+.manual-content h2,
+.manual-content h3,
+.manual-content h4,
+.manual-content h5,
+.manual-content h6 {
+  color: #f8fafc;
+  font-weight: 600;
+  margin: 1.25em 0 0.5em;
+  line-height: 1.3;
+}
+.manual-content h1 { font-size: 1.5rem; border-bottom: 1px solid #334155; padding-bottom: 0.3em; }
+.manual-content h2 { font-size: 1.25rem; border-bottom: 1px solid #334155; padding-bottom: 0.2em; }
+.manual-content h3 { font-size: 1.125rem; }
+.manual-content h4 { font-size: 1rem; }
+.manual-content p { margin: 0.75em 0; }
+.manual-content a { color: #60a5fa; text-decoration: underline; }
+.manual-content a:hover { color: #93c5fd; }
+.manual-content ul,
+.manual-content ol { margin: 0.75em 0; padding-left: 1.5em; }
+.manual-content ul { list-style: disc; }
+.manual-content ol { list-style: decimal; }
+.manual-content li { margin: 0.25em 0; }
+.manual-content li > p { margin: 0.25em 0; }
+.manual-content blockquote {
+  margin: 0.75em 0;
+  padding: 0.25em 0.9em;
+  border-left: 3px solid #475569;
+  color: #cbd5e1;
+  background: rgba(51, 65, 85, 0.25);
+  border-radius: 0 4px 4px 0;
+}
+.manual-content code {
+  background: #0f172a;
+  color: #f1f5f9;
+  padding: 0.15em 0.4em;
+  border-radius: 4px;
+  font-size: 0.9em;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+.manual-content pre {
+  background: #0f172a;
+  border: 1px solid #334155;
+  border-radius: 6px;
+  padding: 0.9em 1em;
+  overflow-x: auto;
+  margin: 0.75em 0;
+}
+.manual-content pre code {
+  background: transparent;
+  padding: 0;
+  font-size: 0.875rem;
+}
+.manual-content table {
+  border-collapse: collapse;
+  margin: 0.75em 0;
+  width: 100%;
+}
+.manual-content th,
+.manual-content td {
+  border: 1px solid #334155;
+  padding: 0.45em 0.7em;
+  text-align: left;
+}
+.manual-content th {
+  background: #1e293b;
+  font-weight: 600;
+}
+.manual-content hr {
+  border: 0;
+  border-top: 1px solid #334155;
+  margin: 1em 0;
+}
+.manual-content img {
+  max-width: 100%;
+  border-radius: 6px;
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,8 @@
     "occt-import-js": "^0.0.23",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1",
     "three": "^0.181.2",
     "uuid": "^13.0.0"
   },

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -1,5 +1,4 @@
 import { Folder, STLModel, StorageStats, STLModelCollection } from "../types";
-import { v4 as uuidv4 } from "uuid";
 
 let API_BASE_URL = "";
 
@@ -228,6 +227,33 @@ export const api = {
       body: formData,
     });
     if (!res.ok) throw new Error("File replacement failed");
+    return res.json();
+  },
+
+  // 14b. GET Manual URL
+  getManualUrl: (model: STLModel) => {
+    return `${API_BASE_URL}/models/${model.id}/manual`;
+  },
+
+  // 14c. UPLOAD Manual
+  uploadManual: async (id: string, file: File): Promise<STLModel> => {
+    const formData = new FormData();
+    formData.append("file", file);
+
+    const res = await fetch(`${API_BASE_URL}/models/${id}/manual`, {
+      method: "PUT",
+      body: formData,
+    });
+    if (!res.ok) throw new Error("Manual upload failed");
+    return res.json();
+  },
+
+  // 14d. DELETE Manual
+  deleteManual: async (id: string): Promise<STLModel> => {
+    const res = await fetch(`${API_BASE_URL}/models/${id}/manual`, {
+      method: "DELETE",
+    });
+    if (!res.ok) throw new Error("Manual delete failed");
     return res.json();
   },
 

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -28,6 +28,7 @@ export interface STLModel {
   description: string;
   dimensions?: { x: number; y: number; z: number };
   thumbnail?: string;
+  manual?: string | null;
 }
 
 export interface STLModelCollection {


### PR DESCRIPTION
## Add optional per-model Markdown manuals
Adds the ability to attach a Markdown manual/documentation to any model, so build notes, print settings, assembly instructions, etc. can live alongside the model itself.

**Thank you for this awesome project!** I am using it to store some of my models. 

⚠️ **Disclaimer**: This feature has been partly built with Claude code as I am not proficient in python. I also used it to write styling and part of the hooks. Part of the code is manually written or edited. Manual testing, code review and any changes are highly welcome. The reason for this feature is that I needed to have manuals for some of the models and sometimes also description how different part fit together. I though others might find this useful, so I thought a pull-request could be a good start. If there is anything that goes against good practice, feel free to suggest changes or commits.

### Features
- **Attach a manual to a model** by uploading a `.md` file or by writing/pasting Markdown directly in an in-app editor.
- **View manuals** in a dedicated modal with full Markdown rendering (GitHub-flavored Markdown via `react-markdown` + `remark-gfm`), including tables, code blocks, blockquotes, and images.
- **Edit and delete** existing manuals from the detail panel or the manual modal.
- **Quick access** to a manual from the model list (book icon shown when a manual exists) and from the detail panel.

### Backend
- New endpoints on the model resource:
  - `GET /api/models/{id}/manual` – fetch the Markdown file
  - `PUT /api/models/{id}/manual` – upload/replace the manual
  - `DELETE /api/models/{id}/manual` – remove the manual
- Manuals are stored as `{model_id}.md` in a dedicated directory, configurable via the `MANUAL_STORAGE` env var (defaults to `<FILE_STORAGE>/manuals`). I did not add new ENV var, it's up to discussion whether it's needed.
- Added a nullable `manual` column to the `models` table, with a safe in-place `ALTER TABLE` migration for existing databases.
- Manuals are cleaned up on single and bulk model deletion, and the DB record self-heals if the file is missing.
- `storage-stats` now walks subdirectories so manual files are counted toward usage.

### Frontend
- New `ManualModal` component (view/edit modes) and manual controls in `DetailPanel` and `ModelList`.
- New `react-markdown` and `remark-gfm` dependencies.
- Manual styles isolated in `components/styles/manual.css`.

### Notes
- The DB migration is backward-compatible; existing models simply have no manual until one is added.

### Screenshots
<img width="287" height="405" alt="Screenshot 2026-06-11 at 18 05 18" src="https://github.com/user-attachments/assets/d9986171-0775-447c-93ba-8e7ff123da63" />

<img width="377" height="937" alt="Screenshot 2026-06-11 at 18 05 31" src="https://github.com/user-attachments/assets/9f4ef431-8618-4c87-af84-655dc85725ae" />

<img width="1728" height="929" alt="Screenshot 2026-06-11 at 18 20 45" src="https://github.com/user-attachments/assets/1df68dc0-e8f2-4ca2-86f2-52b9cba96263" />
