### PR TITLE
Add MakerWorld imports and slicer launcher options

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -19,7 +19,7 @@ from typing import Optional, List, Dict, Any, Union
 from pydantic import BaseModel
 
 
-from importers import printables
+from importers import makerworld, printables
 
 DB_PATH = os.getenv("DB_PATH", "data.db")
 UPLOAD_DIR = Path(os.getenv("FILE_STORAGE", "./app/uploads"))
@@ -77,10 +77,23 @@ def init_db():
         )
         """
     )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS settings (
+            key TEXT PRIMARY KEY,
+            value TEXT
+        )
+        """
+    )
     try:
         cur.execute("ALTER TABLE models ADD COLUMN manual TEXT")
     except sqlite3.OperationalError:
         pass
+    if os.getenv("MAKERWORLD_BAMBU_TOKEN"):
+        cur.execute(
+            "INSERT OR IGNORE INTO settings(key,value) VALUES (?,?)",
+            ("makerworld_bambu_token", os.getenv("MAKERWORLD_BAMBU_TOKEN")),
+        )
     conn.commit()
 
     # seed folders if empty
@@ -135,6 +148,30 @@ def save_upload_file(upload_file: UploadFile, dest_path: str) -> int:
         shutil.copyfileobj(upload_file.file, buffer)
     size = os.path.getsize(dest_path)
     return size
+
+
+def get_setting(key: str) -> Optional[str]:
+    conn = get_db_conn()
+    row = conn.execute("SELECT value FROM settings WHERE key=?", (key,)).fetchone()
+    conn.close()
+    return row["value"] if row else None
+
+
+def set_setting(key: str, value: str):
+    conn = get_db_conn()
+    conn.execute(
+        "INSERT INTO settings(key,value) VALUES (?,?) ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+        (key, value),
+    )
+    conn.commit()
+    conn.close()
+
+
+def clear_setting(key: str):
+    conn = get_db_conn()
+    conn.execute("DELETE FROM settings WHERE key=?", (key,))
+    conn.commit()
+    conn.close()
 
 
 # --- Folder endpoints ---
@@ -538,10 +575,42 @@ def storage_stats():
     return {"used": used, "total": total}
 
 
-## PRINTABLES IMPORTS
-@app.post("/api/printables/importid")
+def importer_for_url(url: str):
+    if "makerworld.com" in url.lower():
+        return makerworld.MakerWorldImporter(), "makerworld"
+    return printables.PrintablesImporter(), "printables"
+
+
+def importer_for_source(source: str):
+    if source == "makerworld":
+        return makerworld.MakerWorldImporter(get_setting("makerworld_bambu_token")), "MakerWorld"
+    return printables.PrintablesImporter(), "Printables"
+
+
+@app.get("/api/settings/makerworld-token")
+def makerworld_token_status():
+    return {"configured": bool(get_setting("makerworld_bambu_token"))}
+
+
+@app.put("/api/settings/makerworld-token")
+def update_makerworld_token(payload: dict):
+    if payload.get("clear") is True:
+        clear_setting("makerworld_bambu_token")
+        return {"configured": False}
+
+    token = str(payload.get("token", "")).strip()
+    if not token:
+        raise HTTPException(status_code=400, detail="Token is required")
+
+    set_setting("makerworld_bambu_token", token)
+    return {"configured": True}
+
+
+## MODEL IMPORTS
+@app.post("/api/import/importid")
 def import_model_by_id(payload: dict):
-    importer = printables.PrintablesImporter()
+    source = payload.get("source", "printables")
+    importer, source_label = importer_for_source(source)
     modelId = payload.get("id")
     modelName = payload.get("name")
     parentId = payload.get("parentId")
@@ -569,7 +638,7 @@ def import_model_by_id(payload: dict):
         else:
             raise ValueError("URL is None")
     except Exception as e:
-        raise e
+        raise HTTPException(status_code=400, detail=str(e))
 
     model = {
         "id": mid,
@@ -579,7 +648,7 @@ def import_model_by_id(payload: dict):
         "size": size,
         "dateAdded": now_ms(),
         "tags": ["imported"],
-        "description": "Imported from Printables",
+        "description": f"Imported from {source_label}",
         "thumbnail": thumbnail
     }
 
@@ -604,21 +673,33 @@ def import_model_by_id(payload: dict):
     return model
 
 
-@app.post("/api/printables/options")
+@app.post("/api/import/options")
 def import_model_options(payload: dict):
-    importer = printables.PrintablesImporter()
     url = payload.get("url")
 
     # Check if url is not None before calling importer
     try:
         if url is not None:
+            importer, _source_label = importer_for_url(url)
             modelData = importer.getModelOptions(url)
             if modelData is not None:
                 return modelData
             raise ValueError("Collection Is Empty")
         raise ValueError("URL is None")
     except Exception as e:
-        raise e
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+## PRINTABLES IMPORTS - compatibility aliases
+@app.post("/api/printables/importid")
+def import_printables_model_by_id(payload: dict):
+    payload["source"] = "printables"
+    return import_model_by_id(payload)
+
+
+@app.post("/api/printables/options")
+def import_printables_model_options(payload: dict):
+    return import_model_options(payload)
 
 
 if __name__ == "__main__":

--- a/backend/importers/makerworld.py
+++ b/backend/importers/makerworld.py
@@ -1,0 +1,160 @@
+import base64
+import re
+from urllib.parse import urlparse
+
+import requests
+
+
+class MakerWorldImporter:
+    """Handles imports from MakerWorld."""
+
+    def __init__(self, token=None):
+        self.session: requests.Session
+        self.api_base = "https://api.bambulab.com/v1"
+        self.token = token
+
+    def _headers(self, token=None):
+        headers = {
+            "Accept": "application/json",
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36",
+            "Referer": "https://makerworld.com/",
+        }
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        return headers
+
+    def _extract_model_id(self, url):
+        match = re.search(r"/models/(\d+)", url)
+        if match:
+            return match.group(1)
+
+        parsed = urlparse(url)
+        match = re.search(r"/models/(\d+)", parsed.path)
+        if match:
+            return match.group(1)
+
+        raise ValueError("Could not find a MakerWorld model ID in the URL")
+
+    def _extract_profile_id(self, url, design):
+        match = re.search(r"profileId[-=](\d+)", url)
+        if not match:
+            return None
+
+        requested_id = match.group(1)
+        for instance in design.get("instances", []) or []:
+            if str(instance.get("id")) == requested_id:
+                return str(instance.get("profileId") or requested_id)
+            if str(instance.get("profileId")) == requested_id:
+                return requested_id
+        return requested_id
+
+    def _get_design(self, model_id):
+        response = self.session.get(
+            f"{self.api_base}/design-service/design/{model_id}",
+            headers=self._headers(),
+            timeout=30,
+        )
+        response.raise_for_status()
+        data = response.json()
+        return data.get("data") or data
+
+    def _thumbnail_url(self, design, instance=None):
+        for candidate in (
+            (instance or {}).get("cover") if instance else None,
+            (instance or {}).get("coverUrl") if instance else None,
+            design.get("cover"),
+            design.get("coverUrl"),
+            design.get("thumbnail"),
+        ):
+            if isinstance(candidate, str) and candidate:
+                return candidate
+        return ""
+
+    def _make_thumbnail(self, url):
+        if not url:
+            return ""
+        response = self.session.get(url, allow_redirects=True, timeout=30)
+        response.raise_for_status()
+        encoded = base64.b64encode(response.content).decode()
+        content_type = response.headers.get("content-type", "image/png").split(";")[0]
+        return f"data:{content_type};base64,{encoded}"
+
+    def getModelOptions(self, url):
+        self.session = requests.Session()
+        try:
+            model_id = self._extract_model_id(url)
+            design = self._get_design(model_id)
+            download_model_id = design.get("modelId") or model_id
+            title = design.get("title") or design.get("name") or f"MakerWorld {model_id}"
+            requested_profile_id = self._extract_profile_id(url, design)
+            instances = design.get("instances", []) or []
+
+            if requested_profile_id:
+                instances = [
+                    instance
+                    for instance in instances
+                    if str(instance.get("profileId")) == requested_profile_id
+                    or str(instance.get("id")) == requested_profile_id
+                ] or [{"profileId": requested_profile_id, "name": title}]
+
+            if not instances:
+                instances = [{"profileId": model_id, "name": title}]
+
+            options = []
+            for instance in instances:
+                profile_id = str(instance.get("profileId") or instance.get("id"))
+                name = instance.get("name") or title
+                if not name.lower().endswith(".3mf"):
+                    name = f"{name}.3mf"
+                options.append(
+                    {
+                        "source": "makerworld",
+                        "parentId": download_model_id,
+                        "id": profile_id,
+                        "name": name,
+                        "folder": "MakerWorld",
+                        "previewPath": self._thumbnail_url(design, instance),
+                        "typeName": "3mf",
+                    }
+                )
+            return options
+        finally:
+            self.session.close()
+
+    def _download_link(self, model_id, profile_id):
+        if not self.token:
+            raise ValueError(
+                "MakerWorld downloads require a Bambu Cloud token in Settings"
+            )
+
+        response = self.session.get(
+            f"{self.api_base}/iot-service/api/user/profile/{profile_id}",
+            params={"model_id": model_id},
+            headers=self._headers(self.token),
+            timeout=30,
+        )
+        response.raise_for_status()
+        data = response.json()
+        payload = data.get("data") or data
+
+        for key in ("url", "downloadUrl", "download_url"):
+            if payload.get(key):
+                return payload[key]
+
+        for item in payload.get("files", []) or []:
+            for key in ("url", "downloadUrl", "download_url"):
+                if item.get(key):
+                    return item[key]
+
+        raise ValueError("MakerWorld did not return a downloadable file URL")
+
+    def importfromId(self, profile_id, model_id, preview_path):
+        self.session = requests.Session()
+        try:
+            download_url = self._download_link(model_id, profile_id)
+            file = self.session.get(download_url, allow_redirects=True, timeout=120)
+            file.raise_for_status()
+            thumbnail = self._make_thumbnail(preview_path)
+            return file, thumbnail
+        finally:
+            self.session.close()

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -382,6 +382,7 @@ const App = () => {
             model.previewPath,
             importFolderId,
             model.typeName,
+            model.source || "printables",
           );
           await handleUpdateSTEPThumbnail(newModel);
           setUploadQueue((prev) => prev - 1);
@@ -991,12 +992,12 @@ const App = () => {
                           type="url"
                           required
                           className="w-full bg-vault-900 border border-vault-700 rounded-md px-3 py-2 text-white focus:border-indigo-500 outline-none placeholder:text-slate-600"
-                          placeholder="https://www.printables.com/model/..."
+                          placeholder="https://www.printables.com/model/... or https://makerworld.com/..."
                           value={importUrl}
                           onChange={(e) => setImportUrl(e.target.value)}
                         />
                         <p className="text-xs text-slate-500 mt-1">
-                          Paste a link from Printables or similar sites
+                          Paste a link from Printables or MakerWorld
                         </p>
                       </div>
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,6 +2,8 @@ FROM node:22-alpine
 
 WORKDIR /app
 
+RUN apk add --no-cache dos2unix
+
 COPY package.json .
 
 RUN npm install

--- a/frontend/components/ModelList.tsx
+++ b/frontend/components/ModelList.tsx
@@ -16,7 +16,12 @@ import {
   BookOpen,
 } from "lucide-react";
 import { STLModel, Folder } from "../types";
-import { api } from "../services/api";
+import {
+  api,
+  getEnabledLaunchSlicers,
+  SLICERS,
+  SlicerType,
+} from "../services/api";
 
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
@@ -104,6 +109,12 @@ const ModelList: React.FC<ModelListProps> = ({
   const [isTouchDevice, setIsTouchDevice] = useState(false);
 
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  const [slicerAnchorEl, setSlicerAnchorEl] =
+    React.useState<null | HTMLElement>(null);
+  const [slicerModel, setSlicerModel] = useState<STLModel | null>(null);
+  const [enabledSlicers, setEnabledSlicers] = useState<SlicerType[]>(() =>
+    getEnabledLaunchSlicers(),
+  );
 
   const VisuallyHiddenInput = styled("input")({
     clip: "rect(0 0 0 0)",
@@ -122,6 +133,17 @@ const ModelList: React.FC<ModelListProps> = ({
     const isTouch =
       "ontouchstart" in window || (navigator.maxTouchPoints ?? 0) > 0;
     setIsTouchDevice(Boolean(isTouch));
+  }, []);
+
+  useEffect(() => {
+    const refreshEnabledSlicers = () =>
+      setEnabledSlicers(getEnabledLaunchSlicers());
+    window.addEventListener("focus", refreshEnabledSlicers);
+    window.addEventListener("storage", refreshEnabledSlicers);
+    return () => {
+      window.removeEventListener("focus", refreshEnabledSlicers);
+      window.removeEventListener("storage", refreshEnabledSlicers);
+    };
   }, []);
 
   const processedModels = useMemo(() => {
@@ -170,6 +192,33 @@ const ModelList: React.FC<ModelListProps> = ({
     result.sort((a, b) => a.name.localeCompare(b.name));
     return result;
   }, [folders, searchQuery]);
+
+  const openSlicerLauncher = (
+    event: React.MouseEvent<HTMLElement>,
+    model: STLModel,
+  ) => {
+    event.preventDefault();
+    event.stopPropagation();
+    const launchSlicers = getEnabledLaunchSlicers();
+    setEnabledSlicers(launchSlicers);
+    if (launchSlicers.length === 1) {
+      window.location.href = api.getSlicerUrl(model, launchSlicers[0]);
+      return;
+    }
+    setSlicerAnchorEl(event.currentTarget);
+    setSlicerModel(model);
+  };
+
+  const closeSlicerMenu = () => {
+    setSlicerAnchorEl(null);
+    setSlicerModel(null);
+  };
+
+  const openModelInSlicer = (slicer: SlicerType) => {
+    if (!slicerModel) return;
+    window.location.href = api.getSlicerUrl(slicerModel, slicer);
+    closeSlicerMenu();
+  };
 
   const handleDragEnter = (e: React.DragEvent) => {
     e.preventDefault();
@@ -628,14 +677,43 @@ const ModelList: React.FC<ModelListProps> = ({
                       <Tooltip title="Open in Slicer">
                         <IconButton
                           aria-label="open in slicer"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                          }}
-                          href={api.getSlicerUrl(model)}
+                          aria-haspopup="menu"
+                          onClick={(e) => openSlicerLauncher(e, model)}
                         >
                           <ScreenShareIcon />
                         </IconButton>
                       </Tooltip>
+                      <Menu
+                        anchorEl={slicerAnchorEl}
+                        open={
+                          Boolean(slicerAnchorEl) &&
+                          slicerModel?.id === model.id
+                        }
+                        onClose={(e) => {
+                          e.stopPropagation();
+                          closeSlicerMenu();
+                        }}
+                        anchorOrigin={{
+                          vertical: "top",
+                          horizontal: "left",
+                        }}
+                        transformOrigin={{
+                          vertical: "bottom",
+                          horizontal: "left",
+                        }}
+                      >
+                        {enabledSlicers.map((slicer) => (
+                          <MenuItem
+                            key={slicer}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              openModelInSlicer(slicer);
+                            }}
+                          >
+                            {SLICERS[slicer].name}
+                          </MenuItem>
+                        ))}
+                      </Menu>
                       {model.manual && (
                         <Tooltip title="Manual">
                           <IconButton

--- a/frontend/components/Settings.tsx
+++ b/frontend/components/Settings.tsx
@@ -3,33 +3,34 @@ import {
   Check,
   ChevronLeft,
   EthernetPort,
-  SettingsIcon,
-  TicketIcon,
+  KeyRound,
   Wrench,
   X,
 } from "lucide-react";
-import { bool } from "three/tsl";
+import {
+  api,
+  ALL_SLICER_TYPES,
+  getEnabledLaunchSlicers,
+  setEnabledLaunchSlicers,
+  SLICERS,
+  SlicerType,
+} from "../services/api";
 
 interface SettingsProps {
   onBack: () => void;
 }
 
-type SlicerType = "orcaslicer" | "prusaslicer" | "bambu" | "cura";
-
-interface SlicerConfig {
-  name: string;
-  protocol: string;
-}
-
-const SLICERS: Record<SlicerType, SlicerConfig> = {
-  orcaslicer: { name: "OrcaSlicer", protocol: "orcaslicer://open?file=" },
-  prusaslicer: { name: "PrusaSlicer", protocol: "prusaslicer://open?file=" },
-  bambu: { name: "Bambu Studio", protocol: "bambustudio://open?file=" },
-  cura: { name: "Cura", protocol: "cura://open?file=" },
-};
-
 const Settings: React.FC<SettingsProps> = ({ onBack }) => {
   const [apiPortStatus, setApiPortStatus] = useState(false);
+  const [makerWorldTokenConfigured, setMakerWorldTokenConfigured] =
+    useState(false);
+  const [makerWorldToken, setMakerWorldToken] = useState("");
+  const [makerWorldTokenStatus, setMakerWorldTokenStatus] = useState<
+    "idle" | "saved" | "cleared" | "error"
+  >("idle");
+  const [launchSlicers, setLaunchSlicers] = useState<SlicerType[]>(() =>
+    getEnabledLaunchSlicers(),
+  );
   // Initialize state directly from localStorage to prevent flash
   const [selectedSlicer, setSelectedSlicer] = useState<SlicerType>(() => {
     const saved = localStorage.getItem("stlvault-slicer");
@@ -47,8 +48,45 @@ const Settings: React.FC<SettingsProps> = ({ onBack }) => {
 
   // Save slicer preference to localStorage when changed
   const handleSlicerChange = (slicer: SlicerType) => {
-    setSelectedSlicer(slicer);
-    localStorage.setItem("stlvault-slicer", slicer);
+    const next = launchSlicers.includes(slicer)
+      ? launchSlicers.filter((item) => item !== slicer)
+      : [...launchSlicers, slicer];
+    const safeNext = next.length ? next : [slicer];
+    setLaunchSlicers(safeNext);
+    setSelectedSlicer(safeNext[0]);
+    setEnabledLaunchSlicers(safeNext);
+  };
+
+  useEffect(() => {
+    api
+      .getMakerWorldTokenStatus()
+      .then((status) => setMakerWorldTokenConfigured(status.configured))
+      .catch(() => setMakerWorldTokenStatus("error"));
+  }, []);
+
+  const handleMakerWorldTokenSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!makerWorldToken.trim()) return;
+
+    try {
+      const status = await api.updateMakerWorldToken(makerWorldToken.trim());
+      setMakerWorldTokenConfigured(status.configured);
+      setMakerWorldToken("");
+      setMakerWorldTokenStatus("saved");
+    } catch (error) {
+      setMakerWorldTokenStatus("error");
+    }
+  };
+
+  const handleMakerWorldTokenClear = async () => {
+    try {
+      const status = await api.clearMakerWorldToken();
+      setMakerWorldTokenConfigured(status.configured);
+      setMakerWorldToken("");
+      setMakerWorldTokenStatus("cleared");
+    } catch (error) {
+      setMakerWorldTokenStatus("error");
+    }
   };
 
   // Save API port preference to localStorage when changed
@@ -99,12 +137,12 @@ const Settings: React.FC<SettingsProps> = ({ onBack }) => {
           </p>
 
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            {(Object.keys(SLICERS) as SlicerType[]).map((slicer) => (
+            {ALL_SLICER_TYPES.map((slicer) => (
               <button
                 key={slicer}
                 onClick={() => handleSlicerChange(slicer)}
                 className={`p-4 rounded-lg border-2 transition-all text-left ${
-                  selectedSlicer === slicer
+                  launchSlicers.includes(slicer)
                     ? "border-blue-500 bg-blue-500/10 shadow-lg shadow-blue-500/20"
                     : "border-vault-700 bg-vault-800 hover:border-vault-600"
                 }`}
@@ -113,7 +151,7 @@ const Settings: React.FC<SettingsProps> = ({ onBack }) => {
                   <span className="font-medium text-white">
                     {SLICERS[slicer].name}
                   </span>
-                  {selectedSlicer === slicer && (
+                  {launchSlicers.includes(slicer) && (
                     <div className="w-2 h-2 bg-blue-500 rounded-full animate-pulse" />
                   )}
                 </div>
@@ -131,6 +169,71 @@ const Settings: React.FC<SettingsProps> = ({ onBack }) => {
               protocol links (e.g., {SLICERS[selectedSlicer].protocol}). The
               exact setup varies by slicer and operating system.
             </p>
+          </div>
+        </div>
+
+        {/* MakerWorld Settings */}
+        <div className="mb-8">
+          <div className="flex items-center gap-2 mb-4">
+            <KeyRound className="w-5 h-5 text-blue-400" />
+            <h3 className="text-lg font-semibold text-white">MakerWorld</h3>
+          </div>
+          <p className="text-sm text-slate-400 mb-4">
+            Add a Bambu Cloud token to enable MakerWorld 3MF downloads.
+          </p>
+          <form onSubmit={handleMakerWorldTokenSubmit}>
+            <div className="grid grid-cols-1 sm:grid-cols-[1fr_auto] gap-3">
+              <input
+                type="password"
+                className="w-full bg-vault-900 border border-vault-700 rounded-md px-3 py-2 text-white focus:border-indigo-500 outline-none placeholder:text-slate-600"
+                placeholder={
+                  makerWorldTokenConfigured
+                    ? "Token configured; paste a new token to replace it"
+                    : "Paste MakerWorld token"
+                }
+                value={makerWorldToken}
+                onChange={(e) => {
+                  setMakerWorldToken(e.target.value);
+                  setMakerWorldTokenStatus("idle");
+                }}
+              />
+              <button
+                type="submit"
+                disabled={!makerWorldToken.trim()}
+                className="px-4 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-500 text-white font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Save
+              </button>
+            </div>
+          </form>
+          <div className="mt-3 flex flex-wrap items-center gap-3">
+            <span
+              className={`text-xs ${
+                makerWorldTokenConfigured ? "text-green-400" : "text-amber-400"
+              }`}
+            >
+              {makerWorldTokenConfigured
+                ? "Token configured"
+                : "Token not configured"}
+            </span>
+            {makerWorldTokenConfigured && (
+              <button
+                type="button"
+                onClick={handleMakerWorldTokenClear}
+                className="text-xs text-slate-400 hover:text-white underline"
+              >
+                Clear token
+              </button>
+            )}
+            {makerWorldTokenStatus === "saved" && (
+              <span className="text-xs text-green-400">Saved</span>
+            )}
+            {makerWorldTokenStatus === "cleared" && (
+              <span className="text-xs text-amber-400">Cleared</span>
+            )}
+            {makerWorldTokenStatus === "error" && (
+              <span className="text-xs text-red-400">Update failed</span>
+            )}
           </div>
         </div>
 

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -11,6 +11,66 @@ if (localStorage.getItem("api-port-override")) {
 
 // --- API SERVICE ---
 
+export type SlicerType =
+  | "orcaslicer"
+  | "bambu"
+  | "elegoo"
+  | "flashforge"
+  | "prusaslicer"
+  | "cura";
+
+export interface SlicerConfig {
+  name: string;
+  protocol: string;
+}
+
+export interface IntegrationTokenStatus {
+  configured: boolean;
+}
+
+export const SLICERS: Record<SlicerType, SlicerConfig> = {
+  orcaslicer: { name: "OrcaSlicer", protocol: "orcaslicer://open?file=" },
+  bambu: { name: "Bambu Studio", protocol: "bambustudio://open?file=" },
+  elegoo: { name: "Elegoo Slicer", protocol: "elegooslicer://open?file=" },
+  flashforge: { name: "FlashPrint", protocol: "flashprint://open?file=" },
+  prusaslicer: { name: "PrusaSlicer", protocol: "prusaslicer://open?file=" },
+  cura: { name: "Cura", protocol: "cura://open?file=" },
+};
+
+export const ALL_SLICER_TYPES = Object.keys(SLICERS) as SlicerType[];
+
+const getSlicerPreference = (): SlicerType => {
+  const saved = localStorage.getItem("stlvault-slicer");
+  return saved && saved in SLICERS ? (saved as SlicerType) : "orcaslicer";
+};
+
+export const getEnabledLaunchSlicers = (): SlicerType[] => {
+  const saved = localStorage.getItem("stlvault-launch-slicers");
+  if (!saved) return [getSlicerPreference()];
+
+  try {
+    const parsed = JSON.parse(saved);
+    const enabled = Array.isArray(parsed)
+      ? parsed.filter((slicer): slicer is SlicerType => slicer in SLICERS)
+      : [];
+    return enabled.length ? enabled : [getSlicerPreference()];
+  } catch {
+    return [getSlicerPreference()];
+  }
+};
+
+export const setEnabledLaunchSlicers = (slicers: SlicerType[]) => {
+  const enabled = slicers.filter((slicer) => slicer in SLICERS);
+  localStorage.setItem(
+    "stlvault-launch-slicers",
+    JSON.stringify(enabled.length ? enabled : [getSlicerPreference()]),
+  );
+  localStorage.setItem(
+    "stlvault-slicer",
+    enabled[0] || getSlicerPreference(),
+  );
+};
+
 export const api = {
   // 1. GET Folders
   getFolders: async (): Promise<Folder[]> => {
@@ -112,23 +172,10 @@ export const api = {
   },
 
   //9b. GET slicer Weblink
-  getSlicerUrl: (model: STLModel) => {
+  getSlicerUrl: (model: STLModel, slicer?: SlicerType) => {
     const modelURL = `${API_BASE_URL}/models/${model.id}/download`;
-
-    // Get user's preferred slicer from localStorage
-    const slicerPreference =
-      localStorage.getItem("stlvault-slicer") || "orcaslicer";
-
-    const slicerProtocols: Record<string, string> = {
-      orcaslicer: "orcaslicer://open?file=",
-      prusaslicer: "prusaslicer://open?file=",
-      bambu: "bambustudio://open?file=",
-      cura: "cura://open?file=",
-    };
-
-    const protocol =
-      slicerProtocols[slicerPreference] || slicerProtocols["orcaslicer"];
-    return `${protocol}${modelURL}`;
+    const protocol = SLICERS[slicer || getSlicerPreference()].protocol;
+    return `${protocol}${encodeURIComponent(modelURL)}`;
   },
 
   // 10. BULK DELETE
@@ -165,7 +212,7 @@ export const api = {
 
   // 13. RETRIEVE MODEL OPTIONS
   retrieveModelOptions: async (url: string): Promise<STLModelCollection[]> => {
-    const res = await fetch(`${API_BASE_URL}/printables/options`, {
+    const res = await fetch(`${API_BASE_URL}/import/options`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ url }),
@@ -182,11 +229,13 @@ export const api = {
     previewPath: string,
     folderId: string,
     typeName: string,
+    source: string = "printables",
   ): Promise<STLModel> => {
-    const res = await fetch(`${API_BASE_URL}/printables/importid`, {
+    const res = await fetch(`${API_BASE_URL}/import/importid`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
+        source,
         id,
         name,
         parentId,
@@ -196,6 +245,34 @@ export const api = {
       }),
     });
     if (!res.ok) throw new Error("Import failed");
+    return res.json();
+  },
+
+  getMakerWorldTokenStatus: async (): Promise<IntegrationTokenStatus> => {
+    const res = await fetch(`${API_BASE_URL}/settings/makerworld-token`);
+    if (!res.ok) throw new Error("Failed to fetch MakerWorld token status");
+    return res.json();
+  },
+
+  updateMakerWorldToken: async (
+    token: string,
+  ): Promise<IntegrationTokenStatus> => {
+    const res = await fetch(`${API_BASE_URL}/settings/makerworld-token`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token }),
+    });
+    if (!res.ok) throw new Error("Failed to update MakerWorld token");
+    return res.json();
+  },
+
+  clearMakerWorldToken: async (): Promise<IntegrationTokenStatus> => {
+    const res = await fetch(`${API_BASE_URL}/settings/makerworld-token`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ clear: true }),
+    });
+    if (!res.ok) throw new Error("Failed to clear MakerWorld token");
     return res.json();
   },
 

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -32,6 +32,7 @@ export interface STLModel {
 }
 
 export interface STLModelCollection {
+  source?: string;
   parentId: string;
   id: string;
   name: string;


### PR DESCRIPTION
## Summary
- add MakerWorld import support for model option lookup and 3MF downloads
- add MakerWorld/Bambu token management in Settings
- add Orca, Bambu Studio, Elegoo Slicer, FlashPrint, PrusaSlicer, and Cura launcher options
- allow selecting one or more slicers from the existing card-style UI; one selected launches directly, multiple selected shows the chooser

## Testing
- python3 -m py_compile backend/app.py backend/importers/makerworld.py
- npm run build
- git diff --check
- changed-file secret scan
- smoke-tested MakerWorld option lookup and 3MF import
- smoke-tested single-slicer direct launch and multi-slicer chooser