### PR TITLE
Add Creality Print slicer option

### DIFF
--- a/frontend/components/Settings.tsx
+++ b/frontend/components/Settings.tsx
@@ -14,7 +14,7 @@ interface SettingsProps {
   onBack: () => void;
 }
 
-type SlicerType = "orcaslicer" | "prusaslicer" | "bambu" | "cura";
+type SlicerType = "orcaslicer" | "prusaslicer" | "bambu" | "cura" | "creality";
 
 interface SlicerConfig {
   name: string;
@@ -26,6 +26,7 @@ const SLICERS: Record<SlicerType, SlicerConfig> = {
   prusaslicer: { name: "PrusaSlicer", protocol: "prusaslicer://open?file=" },
   bambu: { name: "Bambu Studio", protocol: "bambustudio://open?file=" },
   cura: { name: "Cura", protocol: "cura://open?file=" },
+  creality: { name: "Creality Print", protocol: "crealityprintlink://open?file=" },
 };
 
 const Settings: React.FC<SettingsProps> = ({ onBack }) => {

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -124,6 +124,7 @@ export const api = {
       prusaslicer: "prusaslicer://open?file=",
       bambu: "bambustudio://open?file=",
       cura: "cura://open?file=",
+      creality: "crealityprintlink://open?file=",
     };
 
     const protocol =


### PR DESCRIPTION
## Summary
- add Creality Print to the slicer settings options
- launch Creality Print with the `crealityprintlink://open?file=` URI handler

Closes #34

## Testing
- `npm install --no-package-lock`
- `npm run build`

Note: `npm ci` currently fails on `main` because `package.json` and `package-lock.json` are out of sync for existing markdown dependencies; this PR does not modify package files.